### PR TITLE
GitHub.js: drop base64 encode which seems to cause 401 not authorised…

### DIFF
--- a/js/services/Github.js
+++ b/js/services/Github.js
@@ -6,7 +6,7 @@ GithubStats.factory('Github', function(SettingsService, $q, $http) {
         token = prompt("Please enter the github auth token");
         localStorage.setItem('token', token);
     }
-    var credentials = Base64.encode('SchizoDuckie:' + localStorage.getItem('token'));
+    var credentials = 'SchizoDuckie:' + localStorage.getItem('token');
 
     var endpoints = {
         repos: 'https://api.github.com/users/%s/repos',


### PR DESCRIPTION
… since April '18